### PR TITLE
ci: setup lint/format with Node 22.18.0 & pnpm 10.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.18.0' # Voltaでpinしたバージョンに合わせる
-          cache: 'pnpm'
+          node-version: '22.18.0' # Voltaのpinと合わせる
 
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.4.0' # packageManager と合わせる
+          version: '10.4.0' # packageManagerと合わせる
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
@@ -30,7 +29,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.18.0'
-          cache: 'pnpm'
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
-name: ci
+name: CI
 
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 jobs:
@@ -11,26 +9,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: pnpm
+          node-version: '22.18.0' # Voltaでpinしたバージョンに合わせる
+          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.4.0' # packageManager と合わせる
+
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -s lint
+      - run: pnpm run lint
 
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: pnpm
+          node-version: '22.18.0'
+          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.4.0'
+
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -s format:check
+      - run: pnpm run format:check


### PR DESCRIPTION
name: ci

on:
pull_request:
push:
branches: [main]

jobs:
lint:
runs-on: ubuntu-latest
steps: - uses: actions/checkout@v4

      - uses: pnpm/action-setup@v4
        with:
          version: 10

      - uses: actions/setup-node@v4
        with:
          node-version: '22'
          cache: 'pnpm'

      - run: pnpm install --frozen-lockfile
      - run: pnpm -s lint
